### PR TITLE
Fix EmulatedTooltip bugs

### DIFF
--- a/release/0PluginLibrary.plugin.js
+++ b/release/0PluginLibrary.plugin.js
@@ -7513,20 +7513,22 @@ class EmulatedTooltip {
             else this.showLeft();
         }
 
+        /** Do not create a new observer each time if one already exists! */
+        if (this.observer) return;
         /** Use an observer in show otherwise you'll cause unclosable tooltips */
-        const observer = new MutationObserver((mutations) => {
+        this.observer = new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
                 const nodes = Array.from(mutation.removedNodes);
                 const directMatch = nodes.indexOf(this.node) > -1;
                 const parentMatch = nodes.some(parent => parent.contains(this.node));
                 if (directMatch || parentMatch) {
                     this.hide();
-                    observer.disconnect();
+                    this.observer.disconnect();
                 }
             });
         });
 
-        observer.observe(document.body, {subtree: true, childList: true});
+        this.observer.observe(document.body, {subtree: true, childList: true});
     }
 
     /** Force showing the tooltip above the node. */

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ module.exports = {
             github_username: "rauenzi",
             twitter_username: "ZackRauen"
         }],
-        version: "1.2.20",
+        version: "1.2.21",
         description: "Gives other plugins utility functions and the ability to emulate v2.",
         github: "https://github.com/rauenzi/BDPluginLibrary",
         github_raw: "https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js"
@@ -17,7 +17,8 @@ module.exports = {
             title: "Bugs Squashed",
             type: "fixed",
             items: [
-                "EmulatedToolips look good again and have more options. Thanks to DorCoMaNdO on GitHub!",
+                "EmulatedTooltips look good again and have more options. Thanks to DorCoMaNdO on GitHub!",
+                "EmulatedTooltips positioning and unclosable Click To Update tooltips fixed by Lighty",
                 "Modals like the alert and confirmation modals should work again.",
                 "Context menus and patches using DCM should work again."
             ]

--- a/src/ui/emulatedtooltip.js
+++ b/src/ui/emulatedtooltip.js
@@ -16,7 +16,7 @@ import Screen from "../structs/screen";
 const getClass = function(sideOrColor) {
     const upperCase = sideOrColor[0].toUpperCase() + sideOrColor.slice(1);
     const tooltipClass = DiscordClasses.Tooltips[`tooltip${upperCase}`];
-    if (tooltipClass) return tooltipClass;
+    if (tooltipClass) return tooltipClass.value;
     return null;
 };
 
@@ -59,6 +59,7 @@ export default class EmulatedTooltip {
         this.isTimestamp = isTimestamp;
         this.disablePointerEvents = disablePointerEvents;
         this.disabled = disabled;
+        this.active = false;
 
         if (!classExists(this.side)) return Logger.err("EmulatedTooltip", `Side ${this.side} does not exist.`);
         if (!classExists(this.style)) return Logger.err("EmulatedTooltip", `Style ${this.style} does not exist.`);
@@ -67,7 +68,7 @@ export default class EmulatedTooltip {
         this.tooltipElement = DOMTools.createElement(`<div class="${DiscordClasses.Tooltips.tooltip} ${getClass(this.style)}"><div class="${DiscordClasses.Tooltips.tooltipPointer}"></div><div class="${DiscordClasses.Tooltips.tooltipContent}">${this.label}</div></div>`);
         this.labelElement = this.tooltipElement.childNodes[1];
         this.element.append(this.tooltipElement);
-        
+
         if (this.disablePointerEvents) {
             this.element.classList.add(DiscordClasses.TooltipLayers.disabledPointerEvents);
             this.tooltipElement.classList.add(DiscordClasses.Tooltips.tooltipDisablePointerEvents);
@@ -78,20 +79,6 @@ export default class EmulatedTooltip {
         this.node.addEventListener("mouseenter", () => {
             if (this.disabled) return;
             this.show();
-
-            const observer = new MutationObserver((mutations) => {
-                mutations.forEach((mutation) => {
-                    const nodes = Array.from(mutation.removedNodes);
-                    const directMatch = nodes.indexOf(this.node) > -1;
-                    const parentMatch = nodes.some(parent => parent.contains(this.node));
-                    if (directMatch || parentMatch) {
-                        this.hide();
-                        observer.disconnect();
-                    }
-                });
-            });
-
-            observer.observe(document.body, {subtree: true, childList: true});
         });
 
         this.node.addEventListener("mouseleave", () => {
@@ -112,12 +99,18 @@ export default class EmulatedTooltip {
 
     /** Hides the tooltip. Automatically called on mouseleave. */
     hide() {
+        /** Don't rehide if already inactive */
+        if (!this.active) return;
+        this.active = false;
         this.element.remove();
         this.tooltipElement.className = this._className;
     }
 
     /** Shows the tooltip. Automatically called on mouseenter. Will attempt to flip if position was wrong. */
     show() {
+        /** Don't reshow if already active */
+        if (this.active) return;
+        this.active = true;
         this.tooltipElement.className = `${DiscordClasses.Tooltips.tooltip} ${getClass(this.style)}`;
         if (this.disablePointerEvents) this.tooltipElement.classList.add(DiscordClasses.Tooltips.tooltipDisablePointerEvents);
         if (this.isTimestamp) this.tooltipElement.classList.add(WebpackModules.getByProps("timestampTooltip").timestampTooltip);
@@ -143,6 +136,21 @@ export default class EmulatedTooltip {
             if (this.canShowRight || (!this.canShowRight && this.preventFlip)) this.showRight();
             else this.showLeft();
         }
+
+        /** Use an observer in show otherwise you'll cause unclosable tooltips */
+        const observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                const nodes = Array.from(mutation.removedNodes);
+                const directMatch = nodes.indexOf(this.node) > -1;
+                const parentMatch = nodes.some(parent => parent.contains(this.node));
+                if (directMatch || parentMatch) {
+                    this.hide();
+                    observer.disconnect();
+                }
+            });
+        });
+
+        observer.observe(document.body, {subtree: true, childList: true});
     }
 
     /** Force showing the tooltip above the node. */

--- a/src/ui/emulatedtooltip.js
+++ b/src/ui/emulatedtooltip.js
@@ -137,20 +137,22 @@ export default class EmulatedTooltip {
             else this.showLeft();
         }
 
+        /** Do not create a new observer each time if one already exists! */
+        if (this.observer) return;
         /** Use an observer in show otherwise you'll cause unclosable tooltips */
-        const observer = new MutationObserver((mutations) => {
+        this.observer = new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
                 const nodes = Array.from(mutation.removedNodes);
                 const directMatch = nodes.indexOf(this.node) > -1;
                 const parentMatch = nodes.some(parent => parent.contains(this.node));
                 if (directMatch || parentMatch) {
                     this.hide();
-                    observer.disconnect();
+                    this.observer.disconnect();
                 }
             });
         });
 
-        observer.observe(document.body, {subtree: true, childList: true});
+        this.observer.observe(document.body, {subtree: true, childList: true});
     }
 
     /** Force showing the tooltip above the node. */


### PR DESCRIPTION
Mmm, [EmulatedToolips](https://github.com/rauenzi/BDPluginLibrary/blob/03f340fb893f1698c87a8bca6ce76a9f79b81150/src/config.js#L20)

Fixes for tooltips:
- throwing error on hover
- not positioning properly due to above error
- not auto closing if manually calling show (especially the `Click To Update` one!)

Please test these changes (and yours in the future) before pushing!
Fixes mentioned above are confirmed working by me, but requires more testing to ensure nothing broke because of them.
Cherrypick the changes if you must.