### PR TITLE
Fixed issue after discord update

### DIFF
--- a/src/ui/settings/types/switch.js
+++ b/src/ui/settings/types/switch.js
@@ -32,10 +32,9 @@ class Switch extends SettingField {
             hideBorder: false,
             value: this.value,
             onChange: (e) => {
-                const checked = e.currentTarget.checked;
-                reactElement.props.value = checked;
+                reactElement.props.value = e;
                 reactElement.forceUpdate();
-                this.onChange(checked);
+                this.onChange(e);
             }
         }), this.getElement());
     }


### PR DESCRIPTION
The onChange event into a boolean for the Switch object, so changing this makes it work with the latest version of discord.

There's probably much more that broke but this was the only thing that caused errors with my plugins using the library.