### PR TITLE
Fix getReactInstance on canary/others soon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pluginlibrary",
-  "version": "1.2.15",
+  "version": "1.2.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluginlibrary",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "description": "Zere's library for BetterDiscord plugins.",
   "repository": {
     "type": "git",

--- a/release/0PluginLibrary.plugin.js
+++ b/release/0PluginLibrary.plugin.js
@@ -136,7 +136,7 @@ module.exports = {
             github_username: "rauenzi",
             twitter_username: "ZackRauen"
         }],
-        version: "1.2.26",
+        version: "1.2.27",
         description: "Gives other plugins utility functions and the ability to emulate v2.",
         github: "https://github.com/rauenzi/BDPluginLibrary",
         github_raw: "https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js"
@@ -146,9 +146,7 @@ module.exports = {
             title: "Bugs Squashed",
             type: "fixed",
             items: [
-                "Updates to match Discord's internal changes for `ChannelStore`",
-                "Fixes an issue with clearing Dropdown settings",
-                "Fixes a reflection bug for PermissionsViewer"
+                "Fixed multiple plugins, settings and other things not working due to not fetching the react instance anymore (thanks Juby210)."
             ]
         }
     ],
@@ -2927,7 +2925,7 @@ class ReactTools {
     static getReactInstance(node) {
         if (!(node instanceof window.jQuery) && !(node instanceof Element)) return undefined;
         const domNode = node instanceof window.jQuery ? node[0] : node;
-        return domNode[Object.keys(domNode).find((key) => key.startsWith("__reactInternalInstance"))];
+        return domNode[Object.keys(domNode).find((key) => key.startsWith("__reactInternalInstance") || key.startsWith('__reactFiber'))];
     }
 
     /**

--- a/release/0PluginLibrary.plugin.js
+++ b/release/0PluginLibrary.plugin.js
@@ -3034,7 +3034,7 @@ class Reflection {
     static reactInternalInstance(node) {
         if (!node) return null;
         if (!Object.keys(node) || !Object.keys(node).length) return null;
-        const riiKey = Object.keys(node).find(k => k.startsWith("__reactInternalInstance"));
+        const riiKey = Object.keys(node).find(k => k.startsWith("__reactInternalInstance") || k.startsWith('__reactFiber'));
         return riiKey ? node[riiKey] : null;
     }
 

--- a/src/config.js
+++ b/src/config.js
@@ -17,9 +17,7 @@ module.exports = {
             title: "Bugs Squashed",
             type: "fixed",
             items: [
-                "Updates to match Discord's internal changes for `ChannelStore`",
-                "Fixes an issue with clearing Dropdown settings",
-                "Fixes a reflection bug for PermissionsViewer"
+                "Fixed multiple plugins, settings and other things not working due to not fetching the react instance anymore (thanks Juby210)."
             ]
         }
     ],

--- a/src/modules/reacttools.js
+++ b/src/modules/reacttools.js
@@ -29,7 +29,7 @@ export default class ReactTools {
     static getReactInstance(node) {
         if (!(node instanceof window.jQuery) && !(node instanceof Element)) return undefined;
         const domNode = node instanceof window.jQuery ? node[0] : node;
-        return domNode[Object.keys(domNode).find((key) => key.startsWith("__reactInternalInstance"))];
+        return domNode[Object.keys(domNode).find((key) => key.startsWith("__reactInternalInstance") || key.startsWith('__reactFiber'))];
     }
 
     /**

--- a/src/modules/reflection.js
+++ b/src/modules/reflection.js
@@ -16,7 +16,7 @@ class Reflection {
     static reactInternalInstance(node) {
         if (!node) return null;
         if (!Object.keys(node) || !Object.keys(node).length) return null;
-        const riiKey = Object.keys(node).find(k => k.startsWith("__reactInternalInstance"));
+        const riiKey = Object.keys(node).find(k => k.startsWith("__reactInternalInstance") || k.startsWith('__reactFiber'));
         return riiKey ? node[riiKey] : null;
     }
 


### PR DESCRIPTION
Major bug, breaks multiple plugins that rely on anything react based.
Fixes provided by @Juby210.
Multi commit to allow cherry picking only the fix.