### PR TITLE
Fix crashing issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluginlibrary",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "description": "Zere's library for BetterDiscord plugins.",
   "repository": {
     "type": "git",

--- a/release/0PluginLibrary.plugin.js
+++ b/release/0PluginLibrary.plugin.js
@@ -1,6 +1,6 @@
 /**
  * @name ZeresPluginLibrary
- * @version 1.2.31
+ * @version 1.2.32
  * @invite TyFxKer
  * @authorLink https://twitter.com/ZackRauen
  * @donate https://paypal.me/ZackRauen
@@ -137,18 +137,17 @@ module.exports = {
             github_username: "rauenzi",
             twitter_username: "IAmZerebos"
         }],
-        version: "1.2.31",
+        version: "1.2.32",
         description: "Gives other plugins utility functions and the ability to emulate v2.",
         github: "https://github.com/rauenzi/BDPluginLibrary",
         github_raw: "https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js"
     },
     changelog: [
         {
-            title: "Fixed Plugin Updates",
+            title: "Fixed Crashing",
             type: "fixed",
             items: [
-                "Fixed plugin updates to stop them crashing Discord.",
-                "Fixed confirmation modal button color."
+                "Fixed a crash after the latest discord update."
             ]
         }
     ],
@@ -528,7 +527,8 @@ __webpack_require__.r(__webpack_exports__);
     get PopoutRoles() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("roleCircle");},
     get UserModal() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("profileBadge");},
     get Textarea() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("channelTextArea", "textArea");},
-    get Popouts() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("popouts", "popout");},
+    get Popouts() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("popouts", "popout");}, // broken, popouts element has been removed.
+    get App() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("app", "mobileApp");},
     get Titles() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("defaultMarginh5");},
     get Notices() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("notice", "colorInfo");},
     get Backdrop() {return _webpackmodules__WEBPACK_IMPORTED_MODULE_1__["default"].getByProps("backdrop");},
@@ -6862,7 +6862,7 @@ class Menu {
                 elementToAdd = submenu;
             }
             layer.append(elementToAdd);
-            layer.appendTo(_modules_discordselectors__WEBPACK_IMPORTED_MODULE_1__["default"].Popouts.popouts.sibling(_modules_discordselectors__WEBPACK_IMPORTED_MODULE_1__["default"].TooltipLayers.layerContainer).toString());
+            layer.appendTo(_modules_discordselectors__WEBPACK_IMPORTED_MODULE_1__["default"].App.app.sibling(_modules_discordselectors__WEBPACK_IMPORTED_MODULE_1__["default"].TooltipLayers.layerContainer).toString());
         // }
         this.element.css("top", mouseY + "px").css("left", mouseX + "px");
 
@@ -8891,7 +8891,7 @@ class Tooltip {
     static create(node, text, options = {}) {return new Tooltip(node, text, options);}
 
     /** Container where the tooltip will be appended. */
-    get container() {return document.querySelector(modules__WEBPACK_IMPORTED_MODULE_0__["DiscordSelectors"].Popouts.popouts.sibling(modules__WEBPACK_IMPORTED_MODULE_0__["DiscordSelectors"].TooltipLayers.layerContainer));}
+    get container() {return document.querySelector(modules__WEBPACK_IMPORTED_MODULE_0__["DiscordSelectors"].App.app.sibling(modules__WEBPACK_IMPORTED_MODULE_0__["DiscordSelectors"].TooltipLayers.layerContainer));}
     /** Boolean representing if the tooltip will fit on screen above the element */
     get canShowAbove() {return this.node.getBoundingClientRect().top - this.element.offsetHeight >= 0;}
     /** Boolean representing if the tooltip will fit on screen below the element */

--- a/src/config.js
+++ b/src/config.js
@@ -14,11 +14,10 @@ module.exports = {
     },
     changelog: [
         {
-            title: "Fixed Plugin Updates",
+            title: "Fixed Crashing",
             type: "fixed",
             items: [
-                "Fixed plugin updates to stop them crashing Discord.",
-                "Fixed confirmation modal button color."
+                "Fixed a crash after the latest discord update."
             ]
         }
     ],

--- a/src/modules/discordclassmodules.js
+++ b/src/modules/discordclassmodules.js
@@ -23,7 +23,8 @@ export default Utilities.memoizeObject({
     get PopoutRoles() {return WebpackModules.getByProps("roleCircle");},
     get UserModal() {return WebpackModules.getByProps("profileBadge");},
     get Textarea() {return WebpackModules.getByProps("channelTextArea", "textArea");},
-    get Popouts() {return WebpackModules.getByProps("popouts", "popout");},
+    get Popouts() {return WebpackModules.getByProps("popouts", "popout");}, // broken, popouts element has been removed.
+    get App() {return WebpackModules.getByProps("app", "mobileApp");},
     get Titles() {return WebpackModules.getByProps("defaultMarginh5");},
     get Notices() {return WebpackModules.getByProps("notice", "colorInfo");},
     get Backdrop() {return WebpackModules.getByProps("backdrop");},

--- a/src/ui/contextmenu.js
+++ b/src/ui/contextmenu.js
@@ -87,7 +87,7 @@ export class Menu {
                 elementToAdd = submenu;
             }
             layer.append(elementToAdd);
-            layer.appendTo(DiscordSelectors.Popouts.popouts.sibling(DiscordSelectors.TooltipLayers.layerContainer).toString());
+            layer.appendTo(DiscordSelectors.App.app.sibling(DiscordSelectors.TooltipLayers.layerContainer).toString());
         // }
         this.element.css("top", mouseY + "px").css("left", mouseX + "px");
 

--- a/src/ui/tooltip.js
+++ b/src/ui/tooltip.js
@@ -90,7 +90,7 @@ export default class Tooltip {
     static create(node, text, options = {}) {return new Tooltip(node, text, options);}
 
     /** Container where the tooltip will be appended. */
-    get container() {return document.querySelector(DiscordSelectors.Popouts.popouts.sibling(DiscordSelectors.TooltipLayers.layerContainer));}
+    get container() {return document.querySelector(DiscordSelectors.App.app.sibling(DiscordSelectors.TooltipLayers.layerContainer));}
     /** Boolean representing if the tooltip will fit on screen above the element */
     get canShowAbove() {return this.node.getBoundingClientRect().top - this.element.offsetHeight >= 0;}
     /** Boolean representing if the tooltip will fit on screen below the element */


### PR DESCRIPTION
A latest discord update removed the "popouts-" container in the dom root. This was causing some bd users to crash when it tried to show a tooltip (e.g for update notifications). I fixed it by targetting the layerContainer from the "app" container now. Hopefully this one won't get removed.