### PR TITLE
Fallback to empty string for formatString in build.js

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,7 +10,7 @@ const releasePath = path.isAbsolute(libConfig.releaseFolder) ? libConfig.release
 const bdFolder = (process.platform == "win32" ? process.env.APPDATA : process.platform == "darwin" ? process.env.HOME + "/Library/Preferences" :  process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : process.env.HOME + "/.config") + "/BetterDiscord/";
 
 const formatString = function(string, values) {
-    for (const val in values) string = string.replace(new RegExp(`{{${val}}}`, "g"), () => values[val]);
+    for (const val in values) string = string.replace(new RegExp(`{{${val}}}`, "g"), () => values[val] ?? "");
     return string;
 };
 


### PR DESCRIPTION
Right now, `formatString` in build.js defaults to printing `undefined` when the value is not specified in config.json. So for example, if the config.json had no values in the info object, it would print:

```js
 * @name PluginName
 * @invite undefined
 * @authorLink undefined
 * @donate undefined
 * @patreon undefined
 * @website undefined
 * @source undefined
  ```
 
This causes BetterDiscord to show buttons for these actions, even though it shouldn't.

With this change, it now defaults to an empty string, so it would instead print:

```js
 * @name PluginName
 * @invite 
 * @authorLink 
 * @donate 
 * @patreon 
 * @website 
 * @source 
  ```

With this, BetterDiscord no longer shows the buttons.